### PR TITLE
Cast statement_number_t to unsigned int in initializer list

### DIFF
--- a/fortran/basicstatement.cpp
+++ b/fortran/basicstatement.cpp
@@ -9,7 +9,7 @@ namespace aid::fortran {
 std::string basic_statement::generate(unit const &u) const {
     auto const code = do_generate(u);
     if (m_number == no_statement_number) return code;
-    auto const symbol = u.find_symbol(symbol_name{m_number});
+    auto const symbol = u.find_symbol(symbol_name{static_cast<unsigned int>(m_number)});
     if (!symbol.referenced) return code;
     return std::format("L{0}: {1}", m_number, code);
     //return std::format("L{0}: puts(\"L{0}:\"); {1}", m_number, code);

--- a/fortran/parser.cpp
+++ b/fortran/parser.cpp
@@ -1502,7 +1502,7 @@ parser::expected<statement_number_t> parser::parse_statement_number() {
 void parser::add_label(statement_number_t number) {
     if (number == no_statement_number) return;
     if (m_current_unit == nullptr) return;
-    auto symbol = m_current_unit->find_symbol(symbol_name{number});
+    auto symbol = m_current_unit->find_symbol(symbol_name{static_cast<unsigned int>(number)});
     symbol.kind = symbolkind::label;
     if (symbol.type == datatype::unknown) {
         symbol.type = datatype::none;


### PR DESCRIPTION
On x86_64 Linux, at least, std::uint_fast32_t (which is what statement_number_t is) is an alias for unsigned long, but symbol_name's constructor takes unsigned int; unsigned long can't be converted to an unsigned int in an initializer list, and this causes compilation failure with Clang.

I don't necessarily advocate for this solution, as casting is an ugly hack. But a proper fix would be more invasive and I don't know the codebase, so can't suggest a better fix offhand.